### PR TITLE
Wait until a second key is combined with caps lock to send a left_control

### DIFF
--- a/macos/karabiner/caps2esc.json
+++ b/macos/karabiner/caps2esc.json
@@ -12,7 +12,8 @@
             },
             "to": [
                 {
-                    "key_code": "left_control"
+                    "key_code": "left_control",
+                    "lazy": true
                 }
             ],
             "to_if_alone": [


### PR DESCRIPTION
Adds `"lazy": true` to the left control sending.

Without `lazy`, pressing caps lock alone will send Ctrl on key down, and Esc on key up. There are some applications that respond to a bare Ctrl press, like Alfred. This causes weird behaviors.

`"lazy": true` was added to Karabiner to address this. With `lazy`, `left_control` will not be sent until it is combined with another key.

So the modified behavior is as such:

1. Caps lock goes down — nothing happens.
2. One of two things happens:
    a. Caps lock is released — Esc is sent
    b. Another key is pressed in conjunction with Caps lock — Left Control (and the other pressed key) are sent.

More info here: https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to/lazy/

And here is Karabiner folks themselves recommending its use in a similar situation: https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/to-if-alone/

Also, thank you so much for this recommendation. I already had Caps Lock bound to Esc, but double-binding it to Esc and Ctrl has been a vim game-changer. :pray: