### PR TITLE
Kanata keyboard vim like key binding configurations for Windows users and Mac users on Windows

### DIFF
--- a/kanata/mac-windows/README.md
+++ b/kanata/mac-windows/README.md
@@ -1,0 +1,47 @@
+# Kanata Configuration for Mac Users Transitioning to Windows
+
+This directory contains Kanata keyboard remapping configuration that helps Mac users maintain a familiar keyboard experience when switching between Mac and Windows environments.
+
+## Contents
+
+- `caps2esc.kbd` - Keyboard configuration file for Kanata
+
+## Purpose
+
+This configuration is designed for Mac users who frequently work in Windows environments and want to maintain consistent keyboard behavior across both operating systems. It provides Vim-style navigation that works identically on both platforms.
+
+## Features
+
+- **Caps Lock** acts as:
+  - **Escape** when tapped
+  - **Vim navigation layer** when held
+- **Modifier keys** (Control, Command/Windows):
+  - Remain in their default positions
+  - For Mac-like modifier key swapping (Command ⟷ Control), use the configuration in the `windows/` directory instead
+
+### Vim Navigation Layer
+
+When holding Caps Lock:
+- `h`, `j`, `k`, `l` → Arrow keys (left, down, up, right)
+- `w` → Move to next word
+- `b` → Move to previous word
+- `e` → Move to end of word
+- `0` → Home (beginning of line)
+- `4` → End of line
+- `d` → Page down
+- `u` → Page up
+
+## Usage
+
+1. Install Kanata on your Windows system
+2. Double-click `start-kanata.bat` to launch Kanata with the configuration
+3. To run on startup:
+   - Create a shortcut to `start-kanata.bat`
+   - Press `Win+R`, type `shell:startup`, and press Enter
+   - Move the shortcut to the startup folder that opens
+
+## Note
+
+The PowerShell script requires Kanata's executable (`kanata.exe`) to be in the same directory as the script. 
+
+*Note: Use this configuration if you don't need modifier key swapping (Command/Control). If you want Mac-like modifiers on Windows, use the configuration in the windows/ directory.* 

--- a/kanata/mac-windows/caps2esc.kbd
+++ b/kanata/mac-windows/caps2esc.kbd
@@ -1,5 +1,6 @@
 ;; Caps to escape/vim-nav configuration for Kanata
 ;; Caps Lock: tap for Escape, hold for Vim navigation
+;; Windows/Command key acts as Control, Control key acts as Windows/Command (unconditional swap)
 
 (defcfg
   process-unmapped-keys yes ;; Allow keys not in defsrc to function normally
@@ -26,6 +27,7 @@
   h j k l
   w b e 0 4 g
   f d u
+  lmet rmet lctl rctl
 )
 
 ;; Define the escape + vim navigation alias
@@ -43,12 +45,13 @@
   wordprev C-left   ;; Previous word
 )
 
-;; Base layer - normal behavior except for caps
+;; Base layer - normal behavior except for caps and modifier swaps
 (deflayer base
   @escvim  ;; caps becomes esc when tapped, activates vimnav when held
   _     _     _     _      ;; h, j, k, l pass through normally
   _     _     _     _     _     _     ;; w, b, e, 0, 4 ($), g pass through normally
   _     _     _     ;; f, d, u pass through normally
+  lctl  lctl  lmet  lmet  ;; Direct mapping: Windows/Command → Control, Control → Windows/Command
 )
 
 ;; Vim navigation layer - active when caps is held
@@ -57,4 +60,5 @@
   left down up right  ;; h, j, k, l become arrow keys
   @wordnext @wordprev right @home @end _  ;; w, b, e, 0, 4 ($), g
   _ @pgdn @pgup  ;; f, d, u (f is kept as-is for find char functionality)
+  lctl  lctl  lmet  lmet  ;; Keep the same key mapping as base layer
 )

--- a/kanata/mac-windows/caps2esc.kbd
+++ b/kanata/mac-windows/caps2esc.kbd
@@ -1,0 +1,60 @@
+;; Caps to escape/vim-nav configuration for Kanata
+;; Caps Lock: tap for Escape, hold for Vim navigation
+
+(defcfg
+  process-unmapped-keys yes ;; Allow keys not in defsrc to function normally
+)
+
+;; Keep the original, working configuration as a reference
+;; (This was the working configuration you shared)
+;;
+;; (defsrc
+;;   caps
+;; )
+;;
+;; (defalias
+;;   escctrl (tap-hold 100 100 esc lctl)
+;; )
+;;
+;; (deflayer base
+;;   @escctrl
+;; )
+
+;; Include all keys we need to remap in defsrc
+(defsrc
+  caps
+  h j k l
+  w b e 0 4 g
+  f d u
+)
+
+;; Define the escape + vim navigation alias
+(defalias
+  escvim (tap-hold 100 100 esc (layer-toggle vimnav))
+  
+  ;; Common key combinations for navigation
+  home home    ;; Beginning of line
+  end end      ;; End of line
+  pgdn pgdn    ;; Page down
+  pgup pgup    ;; Page up
+  
+  ;; Word movement
+  wordnext C-right  ;; Next word
+  wordprev C-left   ;; Previous word
+)
+
+;; Base layer - normal behavior except for caps
+(deflayer base
+  @escvim  ;; caps becomes esc when tapped, activates vimnav when held
+  _     _     _     _      ;; h, j, k, l pass through normally
+  _     _     _     _     _     _     ;; w, b, e, 0, 4 ($), g pass through normally
+  _     _     _     ;; f, d, u pass through normally
+)
+
+;; Vim navigation layer - active when caps is held
+(deflayer vimnav
+  _      ;; caps key remains the modifier
+  left down up right  ;; h, j, k, l become arrow keys
+  @wordnext @wordprev right @home @end _  ;; w, b, e, 0, 4 ($), g
+  _ @pgdn @pgup  ;; f, d, u (f is kept as-is for find char functionality)
+)

--- a/kanata/mac-windows/start-kanata.bat
+++ b/kanata/mac-windows/start-kanata.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File "%~dp0start-kanata.ps1" 

--- a/kanata/mac-windows/start-kanata.ps1
+++ b/kanata/mac-windows/start-kanata.ps1
@@ -1,0 +1,4 @@
+# Start Kanata keyboard remapper with the caps2esc configuration
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptPath
+Start-Process -FilePath "$scriptPath\kanata.exe" -ArgumentList "--cfg", "$scriptPath\caps2esc.kbd" -WindowStyle Hidden 

--- a/kanata/windows/README.md
+++ b/kanata/windows/README.md
@@ -13,8 +13,6 @@ This directory contains Kanata keyboard remapping configuration files specifical
 - **Caps Lock** acts as:
   - **Escape** when tapped
   - **Vim navigation layer** when held
-- **Windows/Command key** is remapped to **Control**
-- **Control key** is remapped to **Windows/Command**
 
 ### Vim Navigation Layer
 

--- a/kanata/windows/README.md
+++ b/kanata/windows/README.md
@@ -1,0 +1,42 @@
+# Kanata Configuration for Windows
+
+This directory contains Kanata keyboard remapping configuration files specifically tailored for Windows systems.
+
+## Contents
+
+- `caps2esc.kbd` - Keyboard configuration file for Kanata
+- `start-kanata.bat` - Windows batch file to easily start Kanata
+- `start-kanata.ps1` - PowerShell script that launches Kanata with the configuration
+
+## Features
+
+- **Caps Lock** acts as:
+  - **Escape** when tapped
+  - **Vim navigation layer** when held
+- **Windows/Command key** is remapped to **Control**
+- **Control key** is remapped to **Windows/Command**
+
+### Vim Navigation Layer
+
+When holding Caps Lock:
+- `h`, `j`, `k`, `l` → Arrow keys (left, down, up, right)
+- `w` → Move to next word
+- `b` → Move to previous word
+- `e` → Move to end of word
+- `0` → Home (beginning of line)
+- `4` → End of line
+- `d` → Page down
+- `u` → Page up
+
+## Usage
+
+1. Install Kanata on your Windows system
+2. Double-click `start-kanata.bat` to launch Kanata with the configuration
+3. To run on startup:
+   - Create a shortcut to `start-kanata.bat`
+   - Press `Win+R`, type `shell:startup`, and press Enter
+   - Move the shortcut to the startup folder that opens
+
+## Note
+
+The PowerShell script requires Kanata's executable (`kanata.exe`) to be in the same directory as the script. 

--- a/kanata/windows/caps2esc.kbd
+++ b/kanata/windows/caps2esc.kbd
@@ -1,6 +1,5 @@
 ;; Caps to escape/vim-nav configuration for Kanata
 ;; Caps Lock: tap for Escape, hold for Vim navigation
-;; Windows/Command key acts as Control, Control key acts as Windows/Command (unconditional swap)
 
 (defcfg
   process-unmapped-keys yes ;; Allow keys not in defsrc to function normally
@@ -27,7 +26,6 @@
   h j k l
   w b e 0 4 g
   f d u
-  lmet rmet lctl rctl
 )
 
 ;; Define the escape + vim navigation alias
@@ -45,13 +43,12 @@
   wordprev C-left   ;; Previous word
 )
 
-;; Base layer - normal behavior except for caps and modifier swaps
+;; Base layer - normal behavior except for caps
 (deflayer base
   @escvim  ;; caps becomes esc when tapped, activates vimnav when held
   _     _     _     _      ;; h, j, k, l pass through normally
   _     _     _     _     _     _     ;; w, b, e, 0, 4 ($), g pass through normally
   _     _     _     ;; f, d, u pass through normally
-  lctl  lctl  lmet  lmet  ;; Direct mapping: Windows/Command → Control, Control → Windows/Command
 )
 
 ;; Vim navigation layer - active when caps is held
@@ -60,5 +57,4 @@
   left down up right  ;; h, j, k, l become arrow keys
   @wordnext @wordprev right @home @end _  ;; w, b, e, 0, 4 ($), g
   _ @pgdn @pgup  ;; f, d, u (f is kept as-is for find char functionality)
-  lctl  lctl  lmet  lmet  ;; Keep the same key mapping as base layer
 )

--- a/kanata/windows/caps2esc.kbd
+++ b/kanata/windows/caps2esc.kbd
@@ -1,0 +1,64 @@
+;; Caps to escape/vim-nav configuration for Kanata
+;; Caps Lock: tap for Escape, hold for Vim navigation
+;; Windows/Command key acts as Control, Control key acts as Windows/Command (unconditional swap)
+
+(defcfg
+  process-unmapped-keys yes ;; Allow keys not in defsrc to function normally
+)
+
+;; Keep the original, working configuration as a reference
+;; (This was the working configuration you shared)
+;;
+;; (defsrc
+;;   caps
+;; )
+;;
+;; (defalias
+;;   escctrl (tap-hold 100 100 esc lctl)
+;; )
+;;
+;; (deflayer base
+;;   @escctrl
+;; )
+
+;; Include all keys we need to remap in defsrc
+(defsrc
+  caps
+  h j k l
+  w b e 0 4 g
+  f d u
+  lmet rmet lctl rctl
+)
+
+;; Define the escape + vim navigation alias
+(defalias
+  escvim (tap-hold 100 100 esc (layer-toggle vimnav))
+  
+  ;; Common key combinations for navigation
+  home home    ;; Beginning of line
+  end end      ;; End of line
+  pgdn pgdn    ;; Page down
+  pgup pgup    ;; Page up
+  
+  ;; Word movement
+  wordnext C-right  ;; Next word
+  wordprev C-left   ;; Previous word
+)
+
+;; Base layer - normal behavior except for caps and modifier swaps
+(deflayer base
+  @escvim  ;; caps becomes esc when tapped, activates vimnav when held
+  _     _     _     _      ;; h, j, k, l pass through normally
+  _     _     _     _     _     _     ;; w, b, e, 0, 4 ($), g pass through normally
+  _     _     _     ;; f, d, u pass through normally
+  lctl  lctl  lmet  lmet  ;; Direct mapping: Windows/Command → Control, Control → Windows/Command
+)
+
+;; Vim navigation layer - active when caps is held
+(deflayer vimnav
+  _      ;; caps key remains the modifier
+  left down up right  ;; h, j, k, l become arrow keys
+  @wordnext @wordprev right @home @end _  ;; w, b, e, 0, 4 ($), g
+  _ @pgdn @pgup  ;; f, d, u (f is kept as-is for find char functionality)
+  lctl  lctl  lmet  lmet  ;; Keep the same key mapping as base layer
+)

--- a/kanata/windows/start-kanata.bat
+++ b/kanata/windows/start-kanata.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -ExecutionPolicy Bypass -File "%~dp0start-kanata.ps1" 

--- a/kanata/windows/start-kanata.ps1
+++ b/kanata/windows/start-kanata.ps1
@@ -1,0 +1,4 @@
+# Start Kanata keyboard remapper with the caps2esc configuration
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptPath
+Start-Process -FilePath "$scriptPath\kanata.exe" -ArgumentList "--cfg", "$scriptPath\caps2esc.kbd" -WindowStyle Hidden 


### PR DESCRIPTION
 Kanata keyboard remapper configurations in the `/kanata` directory, focusing on helping Mac users transition to Windows environments.

### Changes:
- Added README.md to the `mac-windows/` directory explaining the Caps Lock → Escape/Vim navigation configuration
- Added README.md to the `windows/` directory documenting the comprehensive configuration that includes:
  - Caps Lock → Escape/Vim navigation 
  - Modifier key swapping (Windows/Command ⟷ Control) to mimic Mac keyboard layout
- Clarified the differences between the two configurations
- Provided detailed usage instructions for both setups
- Documented the Vim navigation layer functionality in both configurations

These README files will help users understand which configuration best fits their needs and how to properly set up and use Kanata for a more Mac-like keyboard experience on Windows.
